### PR TITLE
Restrict CW logs permissions to bare minimum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.py?
 lambda-monkey.zip
 venv
+.DS_Store

--- a/cloudformation/src/lambda.py
+++ b/cloudformation/src/lambda.py
@@ -25,7 +25,9 @@ lambda_policy = Policy(
             {
                 "Effect": "Allow",
                 "Action": [
-                    "logs:*",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
                 ],
                 "Resource": "arn:aws:logs:*:*:*"
             },

--- a/cloudformation/templates/lambda.json
+++ b/cloudformation/templates/lambda.json
@@ -68,7 +68,9 @@
                             "Statement": [
                                 {
                                     "Action": [
-                                        "logs:*"
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
                                     ],
                                     "Effect": "Allow",
                                     "Resource": "arn:aws:logs:*:*:*"


### PR DESCRIPTION
As per http://docs.aws.amazon.com/lambda/latest/dg/intro-permission-model.html . Tested in our dev account.