### PR TITLE
Set default probability to 0

### DIFF
--- a/src/chaos.py
+++ b/src/chaos.py
@@ -7,7 +7,7 @@ import boto3
 
 
 PROBABILITY_TAG = "chaos-lambda-termination"
-DEFAULT_PROBABILITY = 1.0 / 6.0
+DEFAULT_PROBABILITY = 0
 
 
 def log(*args):


### PR DESCRIPTION
Setting the default probability to a non-zero value essentially assumes that all ASGs in this account / region are eligible for termination. This can be pretty dangerous, especially when an account is shared between different teams.

Setting this value to 0 would make it an opt-in, rather than opt-out.

Couldn't get the tests to run on my machine, so not sure if I'm breaking any.